### PR TITLE
update broken link in .prettierrc

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ const questions = [
     default: `# .prettierrc
 # Use this file to define your defaults for prettier
 # For a list of all available options:
-# https://github.com/prettier/prettier#basic-configuration
+# https://prettier.io/docs/en/options.html
 printWidth: 80
 singleQuote: true
 semi: false


### PR DESCRIPTION
It seems the Prettier folks have removed the linked section from their README. This patch replaces the link with an up-to-date version of the same information.